### PR TITLE
Added tracking of the logged in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Tracking image works right after you finish step 5 of Installation above. That m
 
 Plugin adds more information (current url, referal url, page title, user language) to the image URL query encoded in base 64 (not humanly readable). This way your Mautic instance receives more valuable data.
 
+If a WP user is logged in, this plugin adds to the URL query also first name, last name, email, WP username and HS blog user name. Your Mautic must be configured to receive such information from public URL. You have to make the Mautic Lead Fields publicly updatable as mentioned in the [documentation](https://www.mautic.org/docs/leads/lead_monitoring.html#lead-fields). The *Publicly available* option is in the configuration of every lead field. The WP username and HS blog name fields are not the default Mautic fields so you'll have to create them manually. Make sure they will have aliases `wp_user` and `hsbloguser`.
+
 ### Mautic Forms
 
 To load a Mautic Form to your WP post, insert this shortcode to the place you want the form to appear:

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,8 @@ Tracking image works right after you finish step 5 of Installation above. That m
 
 There will be probably longer URL query string at the end of the tracking image URL. It is encoded additional data about the page (title, url, referrer, language).
 
+If a WP user is logged in, this plugin adds to the URL query also first name, last name, email, WP username and HS blog user name. Your Mautic must be configured to receive such information from public URL. You have to make the Mautic Lead Fields publicly updatable as mentioned in the [documentation](https://www.mautic.org/docs/leads/lead_monitoring.html#lead-fields). The *Publicly available* option is in the configuration of every lead field. The WP username and HS blog name fields are not the default Mautic fields so you'll have to create them manually. Make sure they will have aliases `wp_user` and `hsbloguser`.
+
 ### Mautic Forms
 
 To load a Mautic Form to your WP post, insert this shortcode to the place you want the form to appear:

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Mautic
  * Plugin URI: https://github.com/mautic/mautic-wordpress
  * Description: This plugin will allow you to add Mautic (Free Open Source Marketing Automation) tracking to your site
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Mautic community
  * Author URI: http://mautic.org
  * License: GPL2
@@ -51,9 +51,15 @@ function wpmautic_function( $atts, $content = null )
 {
 	$options = get_option('wpmautic_options');
 	$url_query = wpmautic_get_url_query();
+	$user_query = wpmautic_get_user_query();
+
+	if ($user_query) {
+		$url_query = array_merge($url_query, $user_query);
+	}
+
 	$encoded_query = urlencode(base64_encode(serialize($url_query)));
 
-	$image   = '<img style="display:none" src="' . trim($options['base_url'], " \t\n\r\0\x0B/") . '/mtracking.gif?d=' . $encoded_query . '" alt="mautic is open source marketing automation" />';
+	$image   = '<img style="display:none" src="' . trim($options['base_url'], " \t\n\r\0\x0B/") . '/mtracking.gif?d=' . $encoded_query . '" alt="Mautic is open source marketing automation" />';
 
 	echo $image;
 }
@@ -114,4 +120,28 @@ function wpmautic_wp_title( $title = '', $sep = '' ) {
 		$title = "$title $sep " . sprintf( __( 'Page %s', 'twentytwelve' ), max( $paged, $page ) );
 
 	return $title;
+}
+
+/**
+ * Adds the user email, and other known elements about the user.
+ *
+ * @return array
+ */
+function wpmautic_get_user_query()
+{
+	global $wp;
+	$attrs = array();
+
+	if ( is_user_logged_in() ) {
+		$current_user = wp_get_current_user();
+		$attrs['email']	 = $current_user->user_email;
+		$attrs['firstname']  = $current_user->user_firstname;
+		$attrs['lastname']  = $current_user->user_lastname;
+		// Following Mautic fields has to be created manually and the fields must match these names
+		$attrs['wp_user']  = $current_user->user_login;
+		$attrs['hsbloguser']  = $current_user->display_name;
+		return $attrs;
+	} else {
+		return null;
+	}
 }


### PR DESCRIPTION
User tracking through Tracking Pixel URL query added.

The most of the code comes from a forum post https://www.mautic.org/community/index.php/1022-wordpress-plugin-what-does-it-do/0#p7707
### Testing

1) [Download the new version of the Mautic-WP plugin](https://github.com/escopecz/mautic-wordpress/archive/user-tracking.zip)
2) Configure Mautic as described in the readme: 

> If a WP user is logged in, this plugin adds to the URL query also first name, last name, email, WP username and HS blog user name. Your Mautic must be configured to receive such information from public URL. You have to make the Mautic Lead Fields publicly updatable as mentioned in the [documentation](https://www.mautic.org/docs/leads/lead_monitoring.html#lead-fields). The _Publicly available_ option is in the configuration of every lead field. The WP username and HS blog name fields are not the default Mautic fields so you'll have to create them manually. Make sure they will have aliases `wp_user` and `hsbloguser`.

3) Test the tracking. Mautic should receive all the information about user to Mautic.
