### PR TITLE
Translation ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,32 @@
+module.exports = function( grunt ) {
+
+	'use strict';
+	var banner = '/**\n * <%= pkg.homepage %>\n * Copyright (c) <%= grunt.template.today("yyyy") %>\n * This file is generated automatically. Do not edit.\n */\n';
+	// Project configuration
+	grunt.initConfig( {
+
+		pkg: grunt.file.readJSON( 'package.json' ),
+
+		makepot: {
+			target: {
+				options: {
+					domainPath: '/languages',
+					mainFile: 'wpmautic.php',
+					potFilename: 'wpmautic.pot',
+					potHeaders: {
+						poedit: true,
+						'x-poedit-keywordslist': true
+					},
+					type: 'wp-plugin',
+					updateTimestamp: true
+				}
+			}
+		},
+	} );
+
+	grunt.loadNpmTasks( 'grunt-wp-i18n' );
+	grunt.registerTask( 'i18n', ['makepot'] );
+
+	grunt.util.linefeed = '\n';
+
+};

--- a/languages/wpmautic.pot
+++ b/languages/wpmautic.pot
@@ -1,0 +1,91 @@
+# Copyright (C) 2016 Mautic community
+# This file is distributed under the GPL2.
+msgid ""
+msgstr ""
+"Project-Id-Version: WP Mautic 1.0.1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wpmautic\n"
+"POT-Creation-Date: 2016-04-14 10:46:08+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#. Plugin Name of the plugin/theme
+msgid "WP Mautic"
+msgstr ""
+
+#: options.php:14
+msgid "Enable Base URL for Mautic Integration."
+msgstr ""
+
+#: options.php:18
+msgid "Save Changes"
+msgstr ""
+
+#: options.php:20
+msgid "Shortcode example for Mautic Form Embed:"
+msgstr ""
+
+#: options.php:21
+msgid "Quick Links"
+msgstr ""
+
+#: options.php:24
+msgid "Plugin docs"
+msgstr ""
+
+#: options.php:27
+msgid "Plugin support"
+msgstr ""
+
+#: options.php:30
+msgid "Mautic project"
+msgstr ""
+
+#: options.php:33
+msgid "Mautic docs"
+msgstr ""
+
+#: options.php:36
+msgid "Mautic forum"
+msgstr ""
+
+#: wpmautic.php:41
+msgid "Settings"
+msgstr ""
+
+#: wpmautic.php:116
+msgid "Page %s"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://github.com/mautic/mautic-wordpress"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"This plugin will allow you to add Mautic (Free Open Source Marketing "
+"Automation) tracking to your site"
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Mautic community"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://mautic.org"
+msgstr ""

--- a/options.php
+++ b/options.php
@@ -10,30 +10,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wpmautic_options_page()
 { ?>
 	 <div>
-		<h2>WP Mautic</h2>
-		<p>Enable Base URL for Mautic Integration.</p>
+		<h2><?php _e( 'WP Mautic', 'mautic-wordpress' ); ?></h2>
+		<p><?php _e( 'Enable Base URL for Mautic Integration.', 'mautic-wordpress' ); ?></p>
 		<form action="options.php" method="post">
 			<?php settings_fields('wpmautic_options'); ?>
 			<?php do_settings_sections('wpmautic'); ?>
 			<input name="Submit" type="submit" value="<?php esc_attr_e('Save Changes'); ?>" />
 		</form>
-		<p>Shortcode example for Mautic Form Embed: <code>[mauticform id="1"]</code></p>
-		<h3>Quick Links</h3>
+		<p><?php _e( 'Shortcode example for Mautic Form Embed:', 'mautic-wordpress' ); ?> <code>[mauticform id="1"]</code></p>
+		<h3><?php _e( 'Quick Links', 'mautic-wordpress' ); ?></h3>
 		<ul>
 			<li>
-				<a href="https://github.com/mautic/mautic-wordpress#mautic-wordpress-plugin" target="_blank">Plugin docs</a>
+				<a href="https://github.com/mautic/mautic-wordpress#mautic-wordpress-plugin" target="_blank"><?php _e( 'Plugin docs', 'mautic-wordpress' ); ?></a>
 			</li>
 			<li>
-				<a href="https://github.com/mautic/mautic-wordpress/issues" target="_blank">Plugin support</a>
+				<a href="https://github.com/mautic/mautic-wordpress/issues" target="_blank"><?php _e( 'Plugin support', 'mautic-wordpress' ); ?></a>
 			</li>
 			<li>
-				<a href="https://mautic.org" target="_blank">Mautic project</a>
+				<a href="https://mautic.org" target="_blank"><?php _e( 'Mautic project', 'mautic-wordpress' ); ?></a>
 			</li>
 			<li>
-				<a href="http://docs.mautic.org/" target="_blank">Mautic docs</a>
+				<a href="http://docs.mautic.org/" target="_blank"><?php _e( 'Mautic docs', 'mautic-wordpress' ); ?></a>
 			</li>
 			<li>
-				<a href="https://www.mautic.org/community/" target="_blank">Mautic forum</a>
+				<a href="https://www.mautic.org/community/" target="_blank"><?php _e( 'Mautic forum', 'mautic-wordpress' ); ?></a>
 			</li>
 		</ul>
 	</div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+
+{
+  "name": "WP-Mautic",
+  "version": "1.0.1",
+  "main": "Gruntfile.js",
+  "author": "Mautic community",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-wp-i18n": "^0.5.0"
+  }
+}

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -6,6 +6,8 @@
  * Version: 1.0.1
  * Author: Mautic community
  * Author URI: http://mautic.org
+ * Text Domain: mautic-wordpress
+ * Domain Path: /languages
  * License: GPL2
  */
 


### PR DESCRIPTION
WordPress uses the gettext libraries and tools for i18n.
https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/

So I want to add libraries for i18n and all text ready for translation.

thanks!
