### PR TITLE
Use tracking image when JavaScript is disabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
   - |
     # Run code sniff when library is loaded
     if [ -f "vendor/bin/phpcs" ]; then
-      vendor/bin/phpcs --standard=phpcs.xml
+      vendor/bin/phpcs -n --standard=phpcs.xml
     fi
   - |
     # Run valid PHPUnit version depending environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Make a solid test suite to check every plugin parts (settings, loading, injection)
+- Add a new setting to activate tracking image as a fallback when javascript is disabled
 
 ### Changed
 - Refactor shortcode handling and put everything in shortcodes.php.

--- a/options.php
+++ b/options.php
@@ -153,7 +153,7 @@ function wpmautic_script_location() {
  * Define the input field for Mautic fallback flag
  */
 function wpmautic_fallback_activated() {
-	$flag = wpmautic_option( 'fallback_activated', '' );
+	$flag = wpmautic_option( 'fallback_activated', false );
 
 	?>
 	<input

--- a/options.php
+++ b/options.php
@@ -56,12 +56,7 @@ function wpmautic_options_page() {
  * Define admin_init hook logic
  */
 function wpmautic_admin_init() {
-	register_setting( 'wpmautic', 'wpmautic_options', array(
-		'sanitize_callback' => 'wpmautic_options_validate',
-		'default' => array(
-			'fallback_activated' => true,
-		),
-	));
+	register_setting( 'wpmautic', 'wpmautic_options', 'wpmautic_options_validate' );
 
 	add_settings_section(
 		'wpmautic_main',

--- a/options.php
+++ b/options.php
@@ -56,7 +56,12 @@ function wpmautic_options_page() {
  * Define admin_init hook logic
  */
 function wpmautic_admin_init() {
-	register_setting( 'wpmautic_options', 'wpmautic_options', 'wpmautic_options_validate' );
+	register_setting( 'wpmautic_options', 'wpmautic_options', array(
+		'sanitize_callback' => 'wpmautic_options_validate',
+		'default' => array(
+			'fallback_activated' => true,
+		),
+	));
 
 	add_settings_section(
 		'wpmautic_main',
@@ -76,6 +81,13 @@ function wpmautic_admin_init() {
 		'wpmautic_script_location',
 		__( 'Tracking script location', 'mautic-wordpress' ),
 		'wpmautic_script_location',
+		'wpmautic',
+		'wpmautic_main'
+	);
+	add_settings_field(
+		'wpmautic_fallback_activated',
+		__( 'Fallback image', 'mautic-wordpress' ),
+		'wpmautic_fallback_activated',
 		'wpmautic',
 		'wpmautic_main'
 	);
@@ -138,6 +150,26 @@ function wpmautic_script_location() {
 }
 
 /**
+ * Define the input field for Mautic fallback flag
+ */
+function wpmautic_fallback_activated() {
+	$flag = wpmautic_option( 'fallback_activated', '' );
+
+	?>
+	<input
+		id="wpmautic_fallback_activated"
+		name="wpmautic_options[fallback_activated]"
+		type="checkbox"
+		value="1"
+		<?php if ( true === $flag ) : ?>checked<?php endif; ?>
+	/>
+	<label for="wpmautic_fallback_activated">
+		<?php esc_html_e( 'Activate it when JavaScript is disabled ?', 'mautic-wordpress' ); ?>
+	</label>
+	<?php
+}
+
+/**
  * Validate base URL input value
  *
  * @param  array $input Input data.
@@ -157,6 +189,10 @@ function wpmautic_options_validate( $input ) {
 	if ( ! in_array( $options['script_location'], array( 'header', 'footer' ), true ) ) {
 		$options['script_location'] = 'header';
 	}
+
+	$options['fallback_activated'] = isset( $input['fallback_activated'] ) && '1' === $input['fallback_activated']
+		? true
+		: false;
 
 	return $options;
 }

--- a/options.php
+++ b/options.php
@@ -56,7 +56,7 @@ function wpmautic_options_page() {
  * Define admin_init hook logic
  */
 function wpmautic_admin_init() {
-	register_setting( 'wpmautic_options', 'wpmautic_options', array(
+	register_setting( 'wpmautic', 'wpmautic_options', array(
 		'sanitize_callback' => 'wpmautic_options_validate',
 		'default' => array(
 			'fallback_activated' => true,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -45,4 +45,18 @@ class OptionsTest extends WP_UnitTestCase
         ));
         $this->assertEquals('footer', wpmautic_option('script_location'));
     }
+
+    public function test_fallback_activated_when_empty()
+    {
+        update_option('wpmautic_options', array());
+        $this->assertTrue(wpmautic_option('fallback_activated'));
+    }
+
+    public function test_fallback_activated_with_value()
+    {
+        update_option('wpmautic_options', array(
+            'fallback_activated' => false
+        ));
+        $this->assertFalse(wpmautic_option('fallback_activated'));
+    }
 }

--- a/tests/OptionsValidationTest.php
+++ b/tests/OptionsValidationTest.php
@@ -19,8 +19,10 @@ class OptionsValidationTest extends WP_UnitTestCase
         $options = wpmautic_options_validate(array());
         $this->assertArrayHasKey('base_url', $options);
         $this->assertArrayHasKey('script_location', $options);
+        $this->assertArrayHasKey('fallback_activated', $options);
         $this->assertEmpty($options['base_url']);
         $this->assertEquals('header', $options['script_location']);
+        $this->assertFalse($options['fallback_activated']);
     }
 
     public function test_validation_with_invalid_script_location()
@@ -47,5 +49,21 @@ class OptionsValidationTest extends WP_UnitTestCase
             'base_url' => 'url'
         ));
         $this->assertEquals('http://url', $options['base_url']);
+    }
+
+    public function test_validation_with_invalid_fallback_activated()
+    {
+        $options = wpmautic_options_validate(array(
+            'fallback_activated' => 'toto'
+        ));
+        $this->assertFalse($options['fallback_activated']);
+    }
+
+    public function test_validation_with_valid_fallback_activated()
+    {
+        $options = wpmautic_options_validate(array(
+            'fallback_activated' => '1'
+        ));
+        $this->assertTrue($options['fallback_activated']);
     }
 }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -1,4 +1,4 @@
-<?php
+test_url_query_payload_without_referer<?php
 /**
  * @package wpmautic\tests
  */
@@ -30,11 +30,20 @@ class PayloadTest extends WP_UnitTestCase
         $this->assertEquals($payload['page_url'], $base_url);
         $this->assertEquals($payload['page_title'], $title);
         $this->assertEquals($payload['language'], get_locale());
-        $this->assertEquals($payload['referrer'], $base_url);
+        if ( version_compare( get_bloginfo('version'), '4.5', '<' ) ) {
+            $this->assertEquals($payload['referrer'], null);
+        } else {
+            $this->assertEquals($payload['referrer'], $base_url);
+        }
     }
 
     public function test_url_query_payload_with_wp_referer()
     {
+        if ( version_compare( get_bloginfo('version'), '4.5', '<' ) ) {
+            $this->markTestSkipped( 'wp_get_raw_referer function was introduced in WP 4.5' );
+            return;
+        }
+
         $base_url = 'http://example.org';
         $_REQUEST['_wp_http_referer'] = 'http://toto.org';
         $this->go_to( $base_url );
@@ -53,6 +62,11 @@ class PayloadTest extends WP_UnitTestCase
 
     public function test_url_query_payload_with_server_referer()
     {
+        if ( version_compare( get_bloginfo('version'), '4.5', '<' ) ) {
+            $this->markTestSkipped( 'wp_get_raw_referer function was introduced in WP 4.5' );
+            return;
+        }
+
         $base_url = 'http://example.org';
         $_SERVER['HTTP_REFERER'] = 'http://toto.org';
         $this->go_to( $base_url );

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package wpmautic\tests
+ */
+
+/**
+ * Ensure that payload data are valid in the current context
+ */
+class PayloadTest extends WP_UnitTestCase
+{
+    public function test_url_query_payload_deprecated_key()
+    {
+        $payload = wpmautic_get_url_query();
+
+        $this->assertArrayNotHasKey('url', $payload);
+        $this->assertArrayNotHasKey('title', $payload);
+        $this->assertArrayHasKey('page_url', $payload);
+        $this->assertArrayHasKey('page_title', $payload);
+    }
+
+    public function test_url_query_payload_without_referer()
+    {
+        $base_url = 'http://example.org';
+        $this->go_to( $base_url );
+
+        $payload = wpmautic_get_url_query();
+
+        $title = sprintf( "%s &#8211; %s", WP_TESTS_TITLE, get_option( 'blogdescription' ) );
+
+        $this->assertEquals($payload['page_url'], $base_url);
+        $this->assertEquals($payload['page_title'], $title);
+        $this->assertEquals($payload['language'], get_locale());
+        $this->assertEquals($payload['referrer'], $base_url);
+    }
+
+    public function test_url_query_payload_with_wp_referer()
+    {
+        $base_url = 'http://example.org';
+        $_REQUEST['_wp_http_referer'] = 'http://toto.org';
+        $this->go_to( $base_url );
+
+        $payload = wpmautic_get_url_query();
+
+        $title = sprintf( "%s &#8211; %s", WP_TESTS_TITLE, get_option( 'blogdescription' ) );
+
+        $this->assertEquals($payload['page_url'], $base_url);
+        $this->assertEquals($payload['page_title'], $title);
+        $this->assertEquals($payload['language'], get_locale());
+        $this->assertEquals($payload['referrer'], 'http://toto.org');
+
+        unset($_REQUEST['_wp_http_referer']);
+    }
+
+    public function test_url_query_payload_with_server_referer()
+    {
+        $base_url = 'http://example.org';
+        $_SERVER['HTTP_REFERER'] = 'http://toto.org';
+        $this->go_to( $base_url );
+
+        $payload = wpmautic_get_url_query();
+
+        $title = sprintf( "%s &#8211; %s", WP_TESTS_TITLE, get_option( 'blogdescription' ) );
+
+        $this->assertEquals($payload['page_url'], $base_url);
+        $this->assertEquals($payload['page_title'], $title);
+        $this->assertEquals($payload['language'], get_locale());
+        $this->assertEquals($payload['referrer'], 'http://toto.org');
+
+        unset($_SERVER['HTTP_REFERER']);
+    }
+}

--- a/tests/ScriptInjectionTest.php
+++ b/tests/ScriptInjectionTest.php
@@ -20,6 +20,15 @@ class ScriptInjectionTest extends WP_UnitTestCase
         return $this->getActualOutput();
     }
 
+    public function setUp()
+    {
+        parent::setUp();
+
+        remove_action('wp_head', 'wpmautic_inject_script');
+        remove_action('wp_footer', 'wpmautic_inject_script');
+        remove_action('wp_footer', 'wpmautic_inject_noscript');
+    }
+
     public function test_script_is_not_injected_when_base_url_is_empty()
     {
         $output = $this->renderRawPage();
@@ -55,7 +64,9 @@ class ScriptInjectionTest extends WP_UnitTestCase
         $this->assertNotContains(sprintf("(window,document,'script','{$base_url}/mtc.js','mt')"), $output);
         $this->assertNotContains("['MauticTrackingObject']", $output);
         $this->assertNotContains("mt('send', 'pageview')", $output);
-        $this->assertNotContains(sprintf("%s/mtracking.gif?d=", $base_url), $output);
+
+        //Fallback activated and <noscript> is always injected in footer !
+        $this->assertContains(sprintf("%s/mtracking.gif?d=", $base_url), $output);
     }
 
     public function test_script_is_injected_in_footer_when_requested()

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -76,4 +76,39 @@ class SettingsTest extends WP_UnitTestCase
         $this->assertContains("wpmautic_options[script_location]", $output);
         $this->assertRegExp('/value="footer"\s+checked/', $output);
     }
+
+    public function test_fallback_activated_setting_with_default()
+    {
+        wpmautic_fallback_activated();
+        $output = $this->getActualOutput();
+        $this->assertContains("wpmautic_fallback_activated", $output);
+        $this->assertContains("wpmautic_options[fallback_activated]", $output);
+        $this->assertContains("checked", $output);
+    }
+
+    public function test_fallback_activated_setting_with_unchecked()
+    {
+        update_option('wpmautic_options', array(
+            'fallback_activated' => false
+        ));
+
+        wpmautic_fallback_activated();
+        $output = $this->getActualOutput();
+        $this->assertContains("wpmautic_fallback_activated", $output);
+        $this->assertContains("wpmautic_options[fallback_activated]", $output);
+        $this->assertNotContains("checked", $output);
+    }
+
+    public function test_fallback_activated_setting_with_checked()
+    {
+        update_option('wpmautic_options', array(
+            'fallback_activated' => true
+        ));
+
+        wpmautic_fallback_activated();
+        $output = $this->getActualOutput();
+        $this->assertContains("wpmautic_fallback_activated", $output);
+        $this->assertContains("wpmautic_options[fallback_activated]", $output);
+        $this->assertContains("checked", $output);
+    }
 }

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -156,9 +156,11 @@ function wpmautic_get_url_query() {
 
 	$attrs = array();
 	$attrs['page_url']   = $current_url;
-	$attrs['page_title'] = wp_get_document_title();
+	$attrs['page_title'] = function_exists( 'wp_get_document_title' )
+		? wp_get_document_title()
+		: wp_title( '&raquo;', false );
 	$attrs['language']   = get_locale();
-	$attrs['referrer']   = wp_get_referer();
+	$attrs['referrer']   = wp_get_raw_referer();
 	if ( false === $attrs['referrer'] ) {
 		$attrs['referrer'] = $current_url;
 	}

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -81,9 +81,9 @@ function wpmautic_option( $option, $default = null ) {
 
 	switch ( $option ) {
 		case 'script_location':
-			return ! isset( $options[$option] ) ? 'header' : $options[$option];
+			return ! isset( $options[ $option ] ) ? 'header' : $options[ $option ];
 		case 'fallback_activated':
-			return isset( $options[$option] ) ? (bool)$options[$option] : true;
+			return isset( $options[ $option ] ) ? (bool) $options[ $option ] : true;
 		default:
 			if ( ! isset( $options[ $option ] ) ) {
 				if ( isset( $default ) ) {
@@ -158,7 +158,7 @@ function wpmautic_get_url_query() {
 	$attrs['page_url']   = $current_url;
 	$attrs['page_title'] = wp_get_document_title();
 	$attrs['language']   = get_locale();
-	$attrs['referrer']   = wp_get_raw_referer();
+	$attrs['referrer']   = wp_get_referer();
 	if ( false === $attrs['referrer'] ) {
 		$attrs['referrer'] = $current_url;
 	}

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -129,4 +129,37 @@ function wpmautic_inject_script() {
 	mt('send', 'pageview');
 </script>
 	<?php
+
+	if ( true === wpmautic_option( 'fallback_activated', false ) ) {
+		global $wp;
+
+		$url_query = wpmautic_get_url_query();
+		$payload = rawurlencode( base64_encode( serialize( $url_query ) ) );
+		?>
+		<noscript>
+			<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  alt="" />
+		</noscript>
+		<?php
+	}
+}
+
+/**
+ * Builds and returns additional data for URL query
+ *
+ * @return array
+ */
+function wpmautic_get_url_query() {
+	global $wp;
+	$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+
+	$attrs = array();
+	$attrs['page_url']   = $current_url;
+	$attrs['page_title'] = wp_get_document_title();
+	$attrs['language']   = get_locale();
+	$attrs['referrer']   = wp_get_raw_referer();
+	if ( false === $attrs['referrer'] ) {
+		$attrs['referrer'] = $current_url;
+	}
+
+	return $attrs;
 }

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -155,7 +155,7 @@ function wpmautic_inject_noscript() {
 	$payload = rawurlencode( base64_encode( serialize( $url_query ) ) );
 	?>
 	<noscript>
-		<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  alt="" />
+		<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  style="display:none;" alt="" />
 	</noscript>
 	<?php
 }

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -81,7 +81,9 @@ function wpmautic_option( $option, $default = null ) {
 
 	switch ( $option ) {
 		case 'script_location':
-			return ! isset( $options['script_location'] ) ? 'header' : $options['script_location'];
+			return ! isset( $options[$option] ) ? 'header' : $options[$option];
+		case 'fallback_activated':
+			return isset( $options[$option] ) ? (bool)$options[$option] : true;
 		default:
 			if ( ! isset( $options[ $option ] ) ) {
 				if ( isset( $default ) ) {

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -109,6 +109,10 @@ function wpmautic_injector() {
 	} else {
 		add_action( 'wp_footer', 'wpmautic_inject_script' );
 	}
+
+	if ( true === wpmautic_option( 'fallback_activated', false ) ) {
+		add_action( 'wp_footer', 'wpmautic_inject_noscript' );
+	}
 }
 
 /**
@@ -131,18 +135,29 @@ function wpmautic_inject_script() {
 	mt('send', 'pageview');
 </script>
 	<?php
+}
 
-	if ( true === wpmautic_option( 'fallback_activated', false ) ) {
-		global $wp;
-
-		$url_query = wpmautic_get_url_query();
-		$payload = rawurlencode( base64_encode( serialize( $url_query ) ) );
-		?>
-		<noscript>
-			<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  alt="" />
-		</noscript>
-		<?php
+/**
+ * Writes Tracking image fallback to the HTML source
+ * This is a separated function because <noscript> tags are not allowed in header !
+ *
+ * @return void
+ */
+function wpmautic_inject_noscript() {
+	$base_url = wpmautic_option( 'base_url', '' );
+	if ( empty( $base_url ) ) {
+		return;
 	}
+
+	global $wp;
+
+	$url_query = wpmautic_get_url_query();
+	$payload = rawurlencode( base64_encode( serialize( $url_query ) ) );
+	?>
+	<noscript>
+		<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  alt="" />
+	</noscript>
+	<?php
 }
 
 /**

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -175,7 +175,9 @@ function wpmautic_get_url_query() {
 		? wp_get_document_title()
 		: wp_title( '&raquo;', false );
 	$attrs['language']   = get_locale();
-	$attrs['referrer']   = wp_get_raw_referer();
+	$attrs['referrer']   = function_exists( 'wp_get_raw_referer' )
+		? wp_get_raw_referer()
+		: null;
 	if ( false === $attrs['referrer'] ) {
 		$attrs['referrer'] = $current_url;
 	}


### PR DESCRIPTION
If the JavaScript is disabled on a webpage, it's important to use the <noscript> as fallback to continue tracking.

- [x] Add unit tests