### PR TITLE
WIP: Add extra information when logged user tracking is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Call translation on all labels, plugin is translation ready !
 - Add a new function `wpmautic_get_tracking_attributes` which defines attributes to be sent through JS and Image trackers.
 - Add a filter `wpmautic_tracking_attributes` to allow developers injecting custom attributes in trackers.
+- Add the ability to track logged user (within an option)
 
 ### Changed
 - Add valid text domain and start official translation process.

--- a/options.php
+++ b/options.php
@@ -86,6 +86,13 @@ function wpmautic_admin_init() {
 		'wpmautic',
 		'wpmautic_main'
 	);
+	add_settings_field(
+		'wpmautic_track_logged_user',
+		__( 'Logged user', 'wp-mautic' ),
+		'wpmautic_track_logged_user',
+		'wpmautic',
+		'wpmautic_main'
+	);
 }
 add_action( 'admin_init', 'wpmautic_admin_init' );
 
@@ -165,6 +172,26 @@ function wpmautic_fallback_activated() {
 }
 
 /**
+ * Define the input field for Mautic logged user tracking flag
+ */
+function wpmautic_track_logged_user() {
+	$flag = wpmautic_option( 'track_logged_user', false );
+
+	?>
+	<input
+		id="wpmautic_track_logged_user"
+		name="wpmautic_options[track_logged_user]"
+		type="checkbox"
+		value="1"
+		<?php if ( true === $flag ) : ?>checked<?php endif; ?>
+	/>
+	<label for="wpmautic_track_logged_user">
+		<?php esc_html_e( 'Track user information when logged ?', 'wp-mautic' ); ?>
+	</label>
+	<?php
+}
+
+/**
  * Validate base URL input value
  *
  * @param  array $input Input data.
@@ -186,6 +213,9 @@ function wpmautic_options_validate( $input ) {
 	}
 
 	$options['fallback_activated'] = isset( $input['fallback_activated'] ) && '1' === $input['fallback_activated']
+		? true
+		: false;
+	$options['track_logged_user'] = isset( $input['track_logged_user'] ) && '1' === $input['track_logged_user']
 		? true
 		: false;
 

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -192,7 +192,7 @@ function wpmautic_get_url_query() {
  * @return array
  */
 function wpmautic_get_tracking_attributes() {
-	$attrs = array();
+	$attrs = wpmautic_get_user_query();
 
 	/**
 	 * Update / add data to be send withing Mautic tracker
@@ -205,4 +205,33 @@ function wpmautic_get_tracking_attributes() {
 	 * @param array $attrs Attributes to be filters, default ['language' => get_locale()]
 	 */
 	return apply_filters( 'wpmautic_tracking_attributes', $attrs );
+}
+
+/**
+ * Extract logged user informations to be send within Mautic tracker
+ *
+ * @return array
+ */
+function wpmautic_get_user_query() {
+	$attrs = array();
+
+	if (
+		true === wpmautic_option( 'track_logged_user', false ) &&
+		is_user_logged_in()
+	) {
+		$current_user = wp_get_current_user();
+		$attrs['email']	 = $current_user->user_email;
+		$attrs['firstname']  = $current_user->user_firstname;
+		$attrs['lastname']  = $current_user->user_lastname;
+
+		// Following Mautic fields has to be created manually and the fields must match these names.
+		$attrs['wp_user']  = $current_user->user_login;
+		$attrs['wp_alias']  = $current_user->display_name;
+		$attrs['wp_registration_date'] = date(
+			'Y-m-d',
+			strtotime( $current_user->user_registered )
+		);
+	}
+
+	return $attrs;
 }

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -84,6 +84,8 @@ function wpmautic_option( $option, $default = null ) {
 			return ! isset( $options[ $option ] ) ? 'header' : $options[ $option ];
 		case 'fallback_activated':
 			return isset( $options[ $option ] ) ? (bool) $options[ $option ] : true;
+		case 'track_logged_user':
+			return isset( $options[ $option ] ) ? (bool) $options[ $option ] : false;
 		default:
 			if ( ! isset( $options[ $option ] ) ) {
 				if ( isset( $default ) ) {


### PR DESCRIPTION
Hello !

I've just started a new PR regarding logged user tracking. Since the codebase as evolved after the #32 and #18 PRs I think it's simpler to start a new one...

@ecoeficiente, I've used your `wpmautic_get_user_query` function.

There are some things to finalize :

- [x] Add a new setting to enable / disable logged user tracking (disable as default)
- [ ] Add unit tests to ensure user tracking behaviour