### PR TITLE
Add alt attribute on the <noscript> img tag.

### DIFF
--- a/wpmautic.php
+++ b/wpmautic.php
@@ -191,7 +191,7 @@ function wpmautic_inject_noscript() {
 	$payload   = rawurlencode( base64_encode( serialize( $url_query ) ) );
 	?>
 	<noscript>
-		<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  style="display:none;" alt="" />
+		<img src="<?php echo esc_url( $base_url ); ?>/mtracking.gif?d=<?php echo esc_attr( $payload ); ?>"  style="display:none;" alt="<?php echo esc_attr__( 'Mautic Tags', 'wp-mautic' ); ?>" />
 	</noscript>
 	<?php
 }


### PR DESCRIPTION
This alt text is using the WordPress translation feature to be easily overriden on the user side.

See #101 