### PR TITLE
Load form and modal javascript async

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -79,7 +79,7 @@ function wpmautic_form_shortcode( $atts ) {
 	}
 
 	return '<script type="text/javascript" ' . sprintf(
-		'src="%s/form/generate.js?id=%s"',
+		'src="%s/form/generate.js?id=%s" async',
 		esc_url( $base_url ),
 		esc_attr( $atts['id'] )
 	) . '></script>';

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -227,7 +227,7 @@ function wpmautic_focus_shortcode( $atts ) {
 	}
 
 	return '<script type="text/javascript" ' . sprintf(
-		'src="%s/focus/%s.js"',
+		'src="%s/focus/%s.js" async',
 		esc_url( $base_url ),
 		esc_attr( $atts['id'] )
 	) . ' async="async"></script>';


### PR DESCRIPTION
Since the form and modal are currently loaded "render-blocking" the styling of the whole page has to wait until the form is generated. This can lead to longer wait times until the page is ready and to visible ugly displays of the content.

By loading the javascript `async`, the rest of the page can be displayed while we are waiting for the form. If the form is at the end of the page (outside the viewport), the user will not notice the longer loading and perceives the page as loading fast.

The same is true for the Mautic modal.

More details about async loading
https://dev.to/duhbhavesh/how-to-eliminate-render-blocking-javascript-using-async-and-defer-3be4