### PR TITLE
tools/makefile-composer-scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,29 @@
         "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^3.0",
         "wp-coding-standards/wpcs": "^1.0"
+    },
+    "scripts": {
+        "build-readme": "@php dist/readme-builder.php",
+        "code-sniffer": [
+            "@composer install --no-interaction",
+            "./vendor/bin/phpcbf --standard=phpcs.xml",
+            "./vendor/bin/phpcs --standard=phpcs.xml"
+        ],
+        "test": [
+            "@composer install --no-interaction",
+            "@check-phpunit",
+            "./vendor/bin/phpunit"
+        ],
+        "test-coverage": [
+            "@composer install --no-interaction",
+            "@check-phpunit",
+            "./vendor/bin/phpunit --coverage-html ./tests-coverage"
+        ]
+    },
+    "scripts-descriptions": {
+        "build-readme": "Updates the current readme.txt file based on README.md and plugin headers",
+        "code-sniffer": "Run phpcbf and phpcs",
+        "test-coverage": "Run phpunit with test coverage",
+        "test": "Run phpunit tests"
     }
 }


### PR DESCRIPTION
Depends on #131 

**Changelog**

- Added: Composer build-readme, code-sniffer, test, and test-coverage scripts for those not running Linux as an alternative to various scripts within Makefile.

**Note**: In testing with [WordPress Develop](https://github.com/WordPress/wordpress-develop) it would seem something has changed since the Makefile was created as tests-coverage corrupts the entire DB. It looks like the WordPress Develop has the command npm run test:coverage, but it takes ages to run. We'll need to do some further testing to see what's going on within the tests that were previously created, but figured having composer handle these tests instead of Makefile would be useful for other developers.