### PR TITLE
Sync Main with Trunk branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
 
       # Steps can also provide arguments, so this configures 10up's action to also generate a zip file.
       with:
+        dry-run: true
         generate-zip: true
 
       # Steps can also set environment variables which can be configured in the Github settings for the

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
+      with:
+        dry-run: true
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
This should have the effect of re-triggering the GitHub Action and it should be blocked by the dummy credentials but the dry-run flag should go through the motions. We think!