### PR TITLE
CI Updates

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -9,7 +9,7 @@
 
 # Exclude development and build files
 node_modules/
-composer.lock
+composer.json
 composer.lock
 package-lock.json
 webpack.config.js

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,6 @@ jobs:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
-      with:
-        dry-run: true
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -79,7 +79,7 @@ function wpmautic_form_shortcode( $atts ) {
 	}
 
 	return '<script type="text/javascript" ' . sprintf(
-		'src="%s/form/generate.js?id=%s" async',
+		'src="%s/form/generate.js?id=%s"',
 		esc_url( $base_url ),
 		esc_attr( $atts['id'] )
 	) . '></script>';
@@ -227,7 +227,7 @@ function wpmautic_focus_shortcode( $atts ) {
 	}
 
 	return '<script type="text/javascript" ' . sprintf(
-		'src="%s/focus/%s.js" async',
+		'src="%s/focus/%s.js"',
 		esc_url( $base_url ),
 		esc_attr( $atts['id'] )
 	) . ' async="async"></script>';

--- a/wpmautic.php
+++ b/wpmautic.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/mautic/mautic-wordpress
  * Contributors: mautic,hideokamoto,shulard,escopecz,dbhurley,macbookandrew
  * Description: This plugin will allow you to add Mautic (Free Open Source Marketing Automation) tracking to your site
- * Version: 2.4.3
+ * Version: 2.4.2
  * Requires at least: 4.6
  * Tested up to: 6.1
  * Author: Mautic community


### PR DESCRIPTION
Bugfix: distignore composer.lock ignored twice.
Removed: dry-run flag from trunk updater.

This also includes fixes for the code not matching the 2.4.2 tag that is the current version.